### PR TITLE
Update to PyO3 0.16, num-bigint 0.4, num-rational 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 num-traits = "0.2"
-num-bigint = "0.2"
+num-bigint = "0.4"
 num-integer = "0.1"
-num-rational = "0.2"
+num-rational = "0.4"
 rand = "0.5"
 rand_pcg = "0.1.1"
 lazy_static = "1.4"
 
 [dependencies.pyo3]
-version = "0.9.0"
+version = "0.16"
 optional = true
 features = ["num-bigint"]

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -181,7 +181,7 @@ where
 mod tests {
     use super::*;
     use num_bigint::BigInt;
-    use num_traits::{One, Pow};
+    use num_traits::One;
 
     #[test]
     fn test_gram_schmidt() {
@@ -281,16 +281,6 @@ mod tests {
         assert!(output == expected);
     }
 
-    // workaround for https://github.com/rust-num/num-bigint/issues/106
-    fn pow<'a, T>(base: &'a Ratio<BigInt>, exponent: &'a T) -> Ratio<BigInt>
-    where
-        &'a BigInt: Pow<&'a T, Output = BigInt>,
-    {
-        let numer = base.numer().pow(exponent);
-        let denom = base.denom().pow(exponent);
-        Ratio::new(numer, denom)
-    }
-
     #[test]
     fn test_lll_reduce() {
         let ints = |v: &[i64]| -> Vec<BigInt> { v.iter().copied().map(BigInt::from).collect() };
@@ -324,7 +314,7 @@ mod tests {
         assert!(output == expected);
 
         // find the minimal polynomial of sin(pi / 7)
-        let multiplier = BigInt::from(1) << 48;
+        let multiplier = BigInt::one() << 48i32;
         // approximation to 1024 fractional bits
         let sin_pi_7_approximation: Ratio<BigInt> =
             "97498727392503287796421964844598099607650972550809391824625445149289352\
@@ -348,7 +338,8 @@ mod tests {
                     BigInt::zero()
                 }
             } else {
-                -pow(&sin_pi_7_approximation, &x)
+                -(&sin_pi_7_approximation)
+                    .pow(x as i32)
                     .mul(&multiplier)
                     .round()
                     .to_integer()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use algebraic_numbers::RealAlgebraicNumber;
 macro_rules! doctest {
     ($x:expr) => {
         #[doc = $x]
-        extern {}
+        extern "C" {}
     };
 }
 

--- a/src/quadratic_numbers.rs
+++ b/src/quadratic_numbers.rs
@@ -575,14 +575,14 @@ impl PartialOrd<BigRational> for RealQuadraticNumber {
         if let Some(lhs) = self.to_ratio() {
             lhs < *rhs
         } else if self.quadratic_term().is_negative() {
-            if self.linear_term() * rhs.denom() < 2 * abs_quadratic_term * rhs.numer() {
+            if self.linear_term() * rhs.denom() < 2i32 * abs_quadratic_term * rhs.numer() {
                 true
             } else {
                 self.constant_term() * rhs.denom() * rhs.denom()
                     > -rhs.numer()
                         * (self.quadratic_term() * rhs.numer() + self.linear_term() * rhs.denom())
             }
-        } else if self.linear_term() * rhs.denom() > -2 * abs_quadratic_term * rhs.numer() {
+        } else if self.linear_term() * rhs.denom() > -2i32 * abs_quadratic_term * rhs.numer() {
             self.constant_term() * rhs.denom() * rhs.denom()
                 > -rhs.numer()
                     * (self.quadratic_term() * rhs.numer() + self.linear_term() * rhs.denom())

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,6 +6,7 @@ use num_integer::Integer;
 use num_rational::Ratio;
 use num_traits::{CheckedDiv, CheckedMul, CheckedRem, NumAssign, One, Signed, ToPrimitive, Zero};
 use std::{
+    convert::TryInto,
     fmt,
     ops::{Add, Div, DivAssign, Mul},
 };
@@ -401,7 +402,7 @@ impl CeilLog2 for BigUint {
         if self.is_zero() {
             None
         } else {
-            Some((self - 1u32).bits())
+            Some((self - 1u32).bits().try_into().unwrap())
         }
     }
 }
@@ -411,7 +412,7 @@ impl FloorLog2 for BigUint {
         if self.is_zero() {
             None
         } else {
-            Some(self.bits() - 1)
+            Some((self.bits() - 1).try_into().unwrap())
         }
     }
 }
@@ -445,7 +446,7 @@ impl TrailingZeros for BigUint {
 impl CeilLog2 for BigInt {
     fn ceil_log2(&self) -> Option<usize> {
         if self.is_positive() {
-            Some((self - 1u32).bits())
+            Some((self - 1u32).bits().try_into().unwrap())
         } else {
             None
         }
@@ -455,7 +456,7 @@ impl CeilLog2 for BigInt {
 impl FloorLog2 for BigInt {
     fn floor_log2(&self) -> Option<usize> {
         if self.is_positive() {
-            Some(self.bits() - 1)
+            Some((self.bits() - 1).try_into().unwrap())
         } else {
             None
         }
@@ -769,7 +770,7 @@ mod tests {
     #[test]
     fn test_trailing_zeros() {
         let one = BigUint::one();
-        for i in 0..=256 {
+        for i in 0..=256u64 {
             for j in 0..=i {
                 let v = (&one << dbg!(i)) | (&one << dbg!(j));
                 assert_eq!(v.trailing_zeros(), Some(j));
@@ -781,12 +782,12 @@ mod tests {
     fn test_ceil_log2() {
         assert_eq!(BigUint::zero().ceil_log2(), None);
         assert_eq!(BigInt::zero().ceil_log2(), None);
-        assert_eq!(0.ceil_log2(), None);
+        assert_eq!(0i32.ceil_log2(), None);
         let one = BigUint::one();
         assert_eq!(one.ceil_log2(), Some(0));
         assert_eq!(BigInt::one().ceil_log2(), Some(0));
-        assert_eq!(1.ceil_log2(), Some(0));
-        for i in 0..=256 {
+        assert_eq!(1i32.ceil_log2(), Some(0));
+        for i in 0..=256usize {
             for j in 0..=i {
                 let v = (&one << dbg!(i)) + (&one << dbg!(j));
                 assert_eq!(v.ceil_log2(), Some(i + 1));
@@ -804,12 +805,12 @@ mod tests {
     fn test_floor_log2() {
         assert_eq!(BigUint::zero().floor_log2(), None);
         assert_eq!(BigInt::zero().floor_log2(), None);
-        assert_eq!(0.floor_log2(), None);
+        assert_eq!(0i32.floor_log2(), None);
         let one = BigUint::one();
         assert_eq!(one.floor_log2(), Some(0));
         assert_eq!(BigInt::one().floor_log2(), Some(0));
-        assert_eq!(1.floor_log2(), Some(0));
-        for i in 0..=256 {
+        assert_eq!(1i32.floor_log2(), Some(0));
+        for i in 0..=256usize {
             for j in 0..=i {
                 let v = (&one << dbg!(i)) | (&one << dbg!(j));
                 assert_eq!(v.floor_log2(), Some(i));


### PR DESCRIPTION
Fixes #2. The updates to `num-bigint` and `num-rational` are necessary to match the versions expected by PyO3. Note that this bumps the required Python version from 3.5 to 3.7 (released 2018-06-27) and the MSRV from nightly-2020-01-21 to 1.40.0 (released 2019-12-19).